### PR TITLE
feat: add middleware to set Reporting-Endpoints response header

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,37 @@ class MyCspViolationListener extends LogCspViolation
 }
 ```
 
+## Middleware
+
+The package registers a `reporting-endpoints` middleware alias that adds the `Reporting-Endpoints` header to responses. Browsers use this header to discover where to POST their reports.
+
+Apply it to specific routes or route groups:
+
+```php
+Route::middleware('reporting-endpoints')->group(function () {
+    Route::get('/', HomeController::class);
+});
+```
+
+To add it globally to all web routes (Laravel 11+, `bootstrap/app.php`):
+
+```php
+use audunru\ReportingApi\Http\Middleware\AddReportingEndpointsHeader;
+use Illuminate\Foundation\Configuration\Middleware;
+
+->withMiddleware(function (Middleware $middleware) {
+    $middleware->web(append: [
+        AddReportingEndpointsHeader::class,
+    ]);
+})
+```
+
+The header value uses the `path` from your config:
+
+```
+Reporting-Endpoints: default="/reports"
+```
+
 ## Configuration
 
 Publish the config file to customise the endpoint path and throttle limit:

--- a/src/Http/Middleware/AddReportingEndpointsHeader.php
+++ b/src/Http/Middleware/AddReportingEndpointsHeader.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace audunru\ReportingApi\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class AddReportingEndpointsHeader
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $response = $next($request);
+        $path = config('reporting-api.path', '/reports');
+        $response->headers->set('Reporting-Endpoints', 'default="'.$path.'"');
+
+        return $response;
+    }
+}

--- a/src/ReportingApiServiceProvider.php
+++ b/src/ReportingApiServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace audunru\ReportingApi;
 
+use audunru\ReportingApi\Http\Middleware\AddReportingEndpointsHeader;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 
@@ -13,5 +14,10 @@ class ReportingApiServiceProvider extends PackageServiceProvider
             ->name('reporting-api')
             ->hasConfigFile()
             ->hasRoutes('reporting-api');
+    }
+
+    public function packageBooted(): void
+    {
+        $this->app['router']->aliasMiddleware('reporting-endpoints', AddReportingEndpointsHeader::class);
     }
 }

--- a/tests/Feature/AddReportingEndpointsHeaderTest.php
+++ b/tests/Feature/AddReportingEndpointsHeaderTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace audunru\ReportingApi\Tests\Feature;
+
+use audunru\ReportingApi\Tests\TestCase;
+
+class AddReportingEndpointsHeaderTest extends TestCase
+{
+    protected function defineRoutes($router): void
+    {
+        $router->get('/header-test', fn () => response('ok'))
+            ->middleware('reporting-endpoints');
+    }
+
+    public function test_adds_reporting_endpoints_header_with_default_path(): void
+    {
+        $this->get('/header-test')
+            ->assertHeader('Reporting-Endpoints', 'default="/reports"');
+    }
+
+    public function test_adds_reporting_endpoints_header_with_custom_path(): void
+    {
+        config(['reporting-api.path' => '/csp']);
+
+        $this->get('/header-test')
+            ->assertHeader('Reporting-Endpoints', 'default="/csp"');
+    }
+}


### PR DESCRIPTION
Closes #1

## Summary

- Adds `AddReportingEndpointsHeader` middleware that sets `Reporting-Endpoints: default="<path>"` on responses, using the `path` value from `config/reporting-api.php`
- Registers a `reporting-endpoints` alias via `packageBooted()` in the service provider so consumers can apply it per route/group
- Documents both per-route-group usage and the global `->web(append: [...])` approach in the README
- Two feature tests covering the default path and a custom configured path

## Test plan

- [x] `composer test` — all 46 tests pass
- [x] `composer verify` — Pint, PHPMD, and PHPUnit all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)