### PR TITLE
fix: exclude all CSRF middleware variants from reports route

### DIFF
--- a/routes/reporting-api.php
+++ b/routes/reporting-api.php
@@ -1,9 +1,11 @@
 <?php
 
 use audunru\ReportingApi\Controllers\ReportingApiController;
+use Illuminate\Foundation\Http\Middleware\PreventRequestForgery;
+use Illuminate\Foundation\Http\Middleware\ValidateCsrfToken;
 use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
 use Illuminate\Support\Facades\Route;
 
 Route::post(config('reporting-api.path', '/reports'), [ReportingApiController::class, 'report'])
     ->middleware(['throttle:'.config('reporting-api.throttle', '60,1')])
-    ->withoutMiddleware([VerifyCsrfToken::class]);
+    ->withoutMiddleware([VerifyCsrfToken::class, ValidateCsrfToken::class, PreventRequestForgery::class]);


### PR DESCRIPTION
## Summary

- In Laravel 13, `VerifyCsrfToken` is deprecated and replaced by `PreventRequestForgery` (new base class) and `ValidateCsrfToken` (extends it)
- The reports route only excluded `VerifyCsrfToken`, so apps using the newer middleware classes would still have CSRF protection blocking browser-posted reports
- Now excludes all three variants so the endpoint works with any Laravel 13 CSRF middleware setup

Closes #2

## Test plan

- [x] All 46 existing tests pass
- [x] `composer verify` clean (Pint + PHPMD + PHPUnit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)