### PR TITLE
feat!: exclude CSP violations from LogReport by default and log at warning level

### DIFF
--- a/src/Listeners/LogReport.php
+++ b/src/Listeners/LogReport.php
@@ -18,13 +18,13 @@ class LogReport
             return;
         }
 
-        Log::channel($this->channel)->info("{$report->type} report received at {$report->url}", [
+        Log::channel($this->channel)->warning("{$report->type} report received at {$report->url}", [
             'report' => $event->getRawReport(),
         ]);
     }
 
     protected function shouldExclude(Report $report): bool
     {
-        return false;
+        return $report->type === 'csp-violation';
     }
 }

--- a/tests/Unit/Listeners/LogReportTest.php
+++ b/tests/Unit/Listeners/LogReportTest.php
@@ -3,6 +3,7 @@
 namespace audunru\ReportingApi\Tests\Unit\Listeners;
 
 use audunru\ReportingApi\DTOs\Report;
+use audunru\ReportingApi\Events\CspViolationReceived;
 use audunru\ReportingApi\Events\DeprecationReportReceived;
 use audunru\ReportingApi\Listeners\LogReport;
 use audunru\ReportingApi\Tests\TestCase;
@@ -26,9 +27,22 @@ class LogReportTest extends TestCase
 
         (new LogReport)->handle($event);
 
-        $spy->shouldHaveReceived('info')
+        $spy->shouldHaveReceived('warning')
             ->once()
             ->with('deprecation report received at https://example.test/page', \Mockery::type('array'));
+    }
+
+    public function test_skips_csp_violations_by_default(): void
+    {
+        $spy = Log::spy();
+
+        (new LogReport)->handle(new CspViolationReceived([
+            'type' => 'csp-violation',
+            'url' => 'https://example.test/page',
+            'body' => [],
+        ]));
+
+        $spy->shouldNotHaveReceived('channel');
     }
 
     public function test_skips_logging_when_excluded(): void


### PR DESCRIPTION
## Summary

- `LogReport` now skips `csp-violation` reports by default — `LogCspViolation` already handles those with a more targeted log message, so registering both no longer causes double-logging
- Log level changed from `info` to `warning`
- Consumers who want the old behavior can subclass `LogReport` and override `shouldExclude()` to return `false`

## Breaking changes

- `LogReport` no longer logs CSP violations by default
- Log level changed from `info` to `warning`

## Test plan

- [x] Existing `test_logs_info_for_any_report` updated to assert `warning` level
- [x] New `test_skips_csp_violations_by_default` confirms CSP events are skipped
- [x] All 47 tests pass

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)