### PR TITLE
chore: add 7-day package cooldowns (Dependabot)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Scaffolds \`.github/dependabot.yml\` with \`cooldown\` blocks on all update entries — prevents PRs for packages published in the last 7 days
- Security updates are automatically exempt from the Dependabot cooldown

## Why
Reduces exposure to supply-chain attacks on freshly released package versions.
See https://cooldowns.dev for background.